### PR TITLE
Set proper page title for images/videos filter

### DIFF
--- a/image_list.php
+++ b/image_list.php
@@ -30,5 +30,6 @@ $tmpl = new OCP\Template('files_filter', 'list', '');
 $tmpl->assign('empty_header', $l->t('No images found'));
 $tmpl->assign('empty_text', $l->t('Any uploaded image will show up here'));
 $tmpl->assign('empty_icon', 'nav-icon-filter-image');
+$tmpl->assign('title', $l->t('Images'));
 $tmpl->printPage();
 

--- a/js/filterfilelist.js
+++ b/js/filterfilelist.js
@@ -82,6 +82,9 @@ $(document).ready(function () {
 						root: OC.linkToRemoteBase('dav'),
 						useHTTPS: OC.getProtocol() === 'https'
 					});
+
+					// set title of page accordingly to the value in the hidden input field
+					this.appName = this.$el.find('.filter-title').first().val();
 				},
 
 				updateEmptyContent: function () {

--- a/templates/list.php
+++ b/templates/list.php
@@ -7,6 +7,7 @@
 </div>
 
 <input type="hidden" name="dir" value="" id="dir">
+<input type="hidden" name="filter-title" value="<?php p($_['title']); ?>" class="filter-title">
 
 <div class="nofilterresults hidden">
 	<div class="icon-search"></div>

--- a/video_list.php
+++ b/video_list.php
@@ -30,5 +30,6 @@ $tmpl = new OCP\Template('files_filter', 'list', '');
 $tmpl->assign('empty_header', $l->t('No videos found'));
 $tmpl->assign('empty_text', $l->t('Any uploaded video will show up here'));
 $tmpl->assign('empty_icon', 'nav-icon-filter-video');
+$tmpl->assign('title', $l->t('Videos'));
 $tmpl->printPage();
 


### PR DESCRIPTION
* before: page title was always "Filter"
* after: page title is "Videos" or "Images" depending on the view  