### PR TITLE
Remove unneeded alt text

### DIFF
--- a/templates/list.php
+++ b/templates/list.php
@@ -30,7 +30,7 @@
 			<a id="modified" class="columntitle" data-sort="mtime"><span><?php p($l->t( 'Modified' )); ?></span><span class="sort-indicator"></span></a>
 			<span class="selectedActions"><a href="" class="delete-selected">
 						<?php p($l->t('Delete'))?>
-					<img class="svg" alt="<?php p($l->t('Delete'))?>"
+					<img class="svg" alt=""
 						 src="<?php print_unescaped(OCP\Template::image_path("core", "actions/delete.svg")); ?>" />
 					</a></span>
 		</th>


### PR DESCRIPTION
It’s not needed cause »Delete« is already written by the row above. @icewind1991 @MorrisJobke 