### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/js/filterfilelist.js
+++ b/js/filterfilelist.js
@@ -158,7 +158,7 @@ $(document).ready(function () {
 							var root = '/files/' + OC.getCurrentUser().uid;
 							var results = searchClient._parseResult(result.body);
 							results = results.map(function(result) {
-								result.path = result.path.substr(root.length);
+								result.path = result.path.slice(root.length);
 								return result;
 							});
 							deferred.resolve(result.status, results);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.